### PR TITLE
feat: отменено поведение при клике

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,7 @@ export default class Form {
 	private waitResponse: boolean = false;
 	private inputs: NodeListOf<HTMLInputElement | HTMLTextAreaElement> | null = null;
 	private _onSubmitHandler?: (e: Event) => void;
+	private _onSubmitClickHandler?: (e: Event) => void;
 
 	private static get defaultParams(): Partial<FormOptions> {
 		return __shared.defaultParams;
@@ -209,6 +210,13 @@ export default class Form {
 
 		if (this.$el) {
 			this.$submit = this.$el.querySelector('input[type="submit"], button[type="submit"]');
+
+			this._onSubmitClickHandler = (e: Event) => {
+				e.preventDefault();
+				this.$el.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
+			};
+			this.$submit?.addEventListener('click', this._onSubmitClickHandler as EventListener);
+
 			if (this.isCorrectArguments()) this.initialization();
 		} else {
 			console.warn('Empty $el');
@@ -838,6 +846,12 @@ export default class Form {
 		if (this._onSubmitHandler) {
 			this.$el.removeEventListener('submit', this._onSubmitHandler as EventListener);
 			this._onSubmitHandler = undefined;
+		}
+
+		// 1.1) Снять click-слушатель с кнопки submit
+		if (this._onSubmitClickHandler) {
+			this.$submit?.removeEventListener('click', this._onSubmitClickHandler as EventListener);
+			this._onSubmitClickHandler = undefined;
 		}
 
 		// 2) Удалить формовый error-блок под инпутами (если есть)


### PR DESCRIPTION
В данном pr введена отмена действий по умолчанию при клике на кнопку, но событие submit все равно происходит (иначе не будет отправки формы) и всплывает к document (что не отменяет действий метрик)