### PR TITLE
fix: accept Release Please changelog format

### DIFF
--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -44,7 +44,11 @@ const changelog = read('CHANGELOG.md');
 const demoHtml = read('demos/index.html');
 const demoJs = read('demos/main.js');
 
-assert(changelog.includes(`## ${version} - `), `CHANGELOG.md must include a ${version} release section`);
+const hasCurrentReleaseSection =
+	changelog.includes(`## ${version} - `) ||
+	changelog.includes(`## [${version}](`) ||
+	changelog.includes(`## [${version}] `);
+assert(hasCurrentReleaseSection, `CHANGELOG.md must include a ${version} release section`);
 
 ['docs/api/README.md', 'docs/demo/README.md', 'docs/recipes/README.md', 'CHANGELOG.md'].forEach(link => {
 	assert(rootReadme.includes(link), `README.md must link to ${link}`);


### PR DESCRIPTION
## Что сделано

- Release Please пишет заголовок changelog как `## [x.y.z](...)`, а старый docs check ждал только ручной формат `## x.y.z - ...`.
- Разрешил оба формата, чтобы release gate проходил на release-коммитах.

## Проверка

- `npm ci`
- `npm run check`
