### PR TITLE
chore(deps): override js-yaml 4.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6426,14 +6426,11 @@
 			"license": "MIT"
 		},
 		"node_modules/argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"sprintf-js": "~1.0.2"
-			}
+			"license": "Python-2.0"
 		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
@@ -7630,20 +7627,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"bin": {
-				"esparse": "bin/esparse.js",
-				"esvalidate": "bin/esvalidate.js"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/estree-walker": {
@@ -9732,14 +9715,23 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "3.14.2",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
+				"argparse": "^2.0.1"
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
@@ -12996,13 +12988,6 @@
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
 			}
-		},
-		"node_modules/sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-			"dev": true,
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/stack-utils": {
 			"version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -83,5 +83,8 @@
 		"ts-node": "^10.9.2",
 		"typescript": "^5.6.3",
 		"vite": "^8.0.16"
+	},
+	"overrides": {
+		"js-yaml": "4.2.0"
 	}
 }


### PR DESCRIPTION
## Summary
- add an npm override for js-yaml@4.2.0
- update package-lock.json so @istanbuljs/load-nyc-config uses the patched js-yaml version
- keep Dependabot enabled and do not add ignore rules

## Why
Dependabot alert #11 reports js-yaml <=4.1.1 as vulnerable. The dependency is transitive through Jest/Istanbul coverage tooling and the upstream parent still allows an older js-yaml range, so the root override pins the patched version.

## Validation
- npm run release:check
- npm audit --audit-level=moderate
- npm ls js-yaml serialize-javascript vite esbuild --all