### PR TITLE
test: configure jest TypeScript globals

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,7 +9,12 @@ const config: Config = {
 	setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 
 	transform: {
-		'^.+\\.tsx?$': 'ts-jest',
+		'^.+\\.tsx?$': [
+			'ts-jest',
+			{
+				tsconfig: '<rootDir>/tsconfig.jest.json',
+			},
+		],
 	},
 
 	modulePathIgnorePatterns: ['<rootDir>/package/'],

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"types": ["jest", "node"],
+		"declaration": false,
+		"declarationDir": null,
+		"outDir": null
+	},
+	"include": ["src/**/*", "__tests__/**/*", "jest.setup.ts"]
+}


### PR DESCRIPTION
## Summary
- add a dedicated tsconfig.jest.json for test compilation
- configure ts-jest to use explicit Jest and Node globals

## Why
The TypeScript 6 Dependabot PR fails because Jest globals are no longer resolved implicitly during ts-jest compilation. Keeping an explicit Jest tsconfig makes test type resolution deterministic while preserving the production tsconfig include scope.

## Validation
- npm run release:check