### PR TITLE
build: set explicit TypeScript root dir

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		"declaration": true,
 		"declarationDir": "dist/types",
 		"outDir": "dist",
+		"rootDir": "src",
 		"strict": true,
 		"esModuleInterop": true,
 		"skipLibCheck": true,


### PR DESCRIPTION
## Summary
- set compilerOptions.rootDir to src

## Why
TypeScript 6 requires an explicit rootDir when declaration output paths would otherwise change the emitted layout. This keeps the package declaration output stable and unblocks the TypeScript 6 Dependabot PR.

## Validation
- npm run release:check