### PR TITLE
build: set TypeScript lib target

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
 	"compilerOptions": {
 		"target": "ES6",
 		"module": "ESNext",
+		"lib": ["DOM", "DOM.Iterable", "ES2019"],
 		"declaration": true,
 		"declarationDir": "dist/types",
 		"outDir": "dist",


### PR DESCRIPTION
## Summary
- explicitly set TypeScript libs to DOM, DOM.Iterable, and ES2019

## Why
The source uses modern APIs such as String.padStart, Object.entries, Array.flatMap, and iterable FormData. TypeScript 6 validates this more strictly, so making the lib target explicit keeps declaration builds stable.

## Validation
- npm run release:check