### PR TITLE
chore: align repository metadata for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/poliklot/form-father.git"
+		"url": "https://github.com/Poliklot/form-father"
 	},
 	"keywords": [
 		"form",
@@ -54,7 +54,7 @@
 	"author": "Poliklot",
 	"license": "MIT",
 	"bugs": {
-		"url": "https://github.com/poliklot/form-father/issues"
+		"url": "https://github.com/Poliklot/form-father/issues"
 	},
 	"sideEffects": false,
 	"devDependencies": {


### PR DESCRIPTION
## Summary
- Match package repository metadata to the GitHub OIDC provenance repository
- Keep package version at 0.8.2 for the pending npm publish retry

## Validation
- npm run release:check