### PR TITLE
chore(deps): ignore blocked Babel 8 updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,9 @@ updates:
       timezone: Europe/Moscow
     open-pull-requests-limit: 10
     ignore:
+      # Babel 8 requires @babel/core 8, while @rollup/plugin-babel 7 peers on Babel 7 only.
+      - dependency-name: '@babel/preset-env'
+        versions: ['8.x']
       # TypeScript 7 is blocked by the current rollup-plugin-dts and ts-jest peer ranges.
       - dependency-name: typescript
         versions: ['7.x']


### PR DESCRIPTION
## Summary
- ignore `@babel/preset-env` 8.x in Dependabot
- document that Babel 8 is blocked until `@rollup/plugin-babel` supports `@babel/core` 8
- keep the existing TypeScript 7 peer-compatibility guard

## Verification
- parsed `.github/dependabot.yml` as YAML
- `npm ci` and `npm run release:check` passed on Node.js 24
- 123/123 tests passed
- npm audit reports 0 vulnerabilities

This is configuration-only and intentionally uses a `chore` commit so it does not trigger an unnecessary package release.