### PR TITLE
fix(package): exclude generated demo bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
 		"RESPONSE_API.md",
 		"CHANGELOG.md",
 		"docs",
-		"demos"
+		"demos/index.html",
+		"demos/main.js",
+		"demos/styles.css"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:types",

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -55,7 +55,7 @@ assert(hasCurrentReleaseSection, `CHANGELOG.md must include a ${version} release
 	assert(englishReadme.includes(link), `docs/en/README.md must link to ${link}`);
 });
 
-['docs', 'demos', 'CHANGELOG.md'].forEach(fileEntry => {
+['docs', 'demos/index.html', 'demos/main.js', 'demos/styles.css', 'CHANGELOG.md'].forEach(fileEntry => {
 	assert(packageJson.files?.includes(fileEntry), `package.json files must include ${fileEntry}`);
 });
 

--- a/scripts/smoke-package.mjs
+++ b/scripts/smoke-package.mjs
@@ -18,11 +18,23 @@ const requiredFiles = [
 	'docs/en/README.md',
 	'docs/recipes/README.md',
 	'demos/index.html',
+	'demos/main.js',
+	'demos/styles.css',
 ];
 
 const missingFiles = requiredFiles.filter(filePath => !fs.existsSync(path.join(rootDir, filePath)));
 if (missingFiles.length > 0) {
 	throw new Error(`Missing package files: ${missingFiles.join(', ')}`);
+}
+
+const expectedDemoPackageFiles = ['demos/index.html', 'demos/main.js', 'demos/styles.css'];
+const missingDemoPackageEntries = expectedDemoPackageFiles.filter(filePath => !packageJson.files?.includes(filePath));
+if (missingDemoPackageEntries.length > 0) {
+	throw new Error(`Missing explicit demo package entries: ${missingDemoPackageEntries.join(', ')}`);
+}
+
+if (packageJson.files.includes('demos')) {
+	throw new Error('package.json files must not include the whole demos directory');
 }
 
 if (!packageJson.exports?.['.']?.import || !packageJson.exports?.['.']?.types) {


### PR DESCRIPTION
## Summary
- replace the broad `demos` package allowlist entry with the three source demo files
- prevent ignored `demos/public` build artifacts from entering a local npm publish
- extend docs/package smoke checks to enforce the explicit package contents

## Why
A clean GitHub Actions checkout produced the correct 21-file tarball, but a local release after running the demo build could include four ignored generated bundles and nearly double the tarball size. Explicit package entries make publishing deterministic in both paths.

## Verification
- Node.js 22: `npm ci` and `npm run release:check`
- Node.js 24: `npm ci` and `npm run release:check`
- 123/123 tests passed on both versions
- pack dry-run remains 21 files even with `demos/public` present
- npm audit: 0 vulnerabilities